### PR TITLE
add vertical toothpick

### DIFF
--- a/vr/components/atoms/Point/actions.js
+++ b/vr/components/atoms/Point/actions.js
@@ -1,6 +1,7 @@
-export function setSelectedPoint(id) {
+export function setSelectedPoint(id, cartesianCoords) {
   return {
     type: 'SET_SELECTED_POINT',
-    id
+    id,
+    cartesianCoords
   }
 }

--- a/vr/components/atoms/Point/index.js
+++ b/vr/components/atoms/Point/index.js
@@ -16,12 +16,12 @@ class Point extends Component {
     let {cartesianCoords, id, selectable = true} = this.props;
 
     const onEnter = () => {
-      this.props.setSelectedPoint(id);
+      this.props.setSelectedPoint(id, cartesianCoords);
       this.setState({selected: true});
     }
 
     const onExit = () => {
-      this.props.setSelectedPoint(null);
+      this.props.setSelectedPoint(null, null);
       this.setState({selected: false});
     }
 

--- a/vr/components/atoms/Toothpick/index.js
+++ b/vr/components/atoms/Toothpick/index.js
@@ -1,0 +1,40 @@
+import React, {Component} from 'react';
+import {Cylinder} from 'react-vr';
+import {connect} from 'react-redux';
+
+class Toothpick extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+    };
+  }
+
+  render() {
+    let {selectedId, cartesianCoords, eyeHeight} = this.props;
+
+    return (selectedId != null) ? (
+      <Cylinder
+        radiusTop={0.5}
+        radiusBottom={0.5}
+        lit={true}
+        dimHeight={cartesianCoords[1] + eyeHeight}
+        style={{
+          transform: [{translate: [cartesianCoords[0], (cartesianCoords[1] - eyeHeight) * 0.5, cartesianCoords[2]]}],
+          color: '#888'
+        }}
+      >
+      </Cylinder>
+    ) : null;
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    eyeHeight: state.world.eyeHeight,
+    selectedId: state.user.selectedPoint,
+    cartesianCoords: state.user.selectedCoords
+  }
+}
+
+export default connect(mapStateToProps)(Toothpick);

--- a/vr/components/scenes/Circos/index.js
+++ b/vr/components/scenes/Circos/index.js
@@ -6,6 +6,7 @@ import {createChromosomeScale} from '../../../utils';
 import Floor from '../../molecules/Floor';
 import Rotunda from '../../molecules/Rotunda';
 import PointCloud from '../../molecules/PointCloud';
+import Toothpick from '../../atoms/Toothpick';
 import {scaleLinear} from 'd3-scale';
 import {min, max, extent} from 'd3-array';
 import data from '../../../../data/90k_GIANT_height_filtered.gene_loc.coords.json';
@@ -74,6 +75,7 @@ class Circos extends React.Component {
         <Floor chromDict={chromDict} radius={radius + 2} eyeHeight={eyeHeight}></Floor>
         <Rotunda yScaleDomain={yScaleDomain} />
         <PointCloud points={coordinates} scaleFactor={[1, 50, 1]} translationFactor={[0, -eyeHeight, 0]} threshold={threshold}/>
+        <Toothpick></Toothpick>
       </View>
     )
   }

--- a/vr/reducers/index.js
+++ b/vr/reducers/index.js
@@ -8,7 +8,10 @@ export default combineReducers({
   user: (state = initialState.user, action) => {
     switch (action && action.type) {
       case 'SET_SELECTED_POINT':
-        return {...state, selectedPoint: action.id}
+        return {...state,
+          selectedPoint: action.id,
+          selectedCoords: action.cartesianCoords
+        }
 
       default:
         return state;


### PR DESCRIPTION
This might not be the right long-term design; it seemed like the minimal way to get access to the coords of the selected point.  But the coords are the cartesian coords, which I assume isn't what you want long-term.  E.g., if you pursue the HUD thing, you'll need access to the untransformed coords of the selected point, and then the right approach for the toothpick would probably be to align with that.

But I wanted to get something running, and this was what I could do in a few hours.  If you don't merge, no hard feelings whatsoever!  At least this PR records the conclusion of the discussion about the right coords for the toothpick cylinder.